### PR TITLE
CI: Skip rather than failing in 2 common scenarios

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -211,9 +211,9 @@ jobs:
     # Only build the package if we can deploy it as a docker image
     env:
       IS_DEPLOYABLE: ${{ secrets.AR_DOCKER_USERNAME != '' }}
-    if: env.IS_DEPLOYABLE == 'true'
     outputs:
       code_changes: ${{ steps.filter.outputs.code_changes }}
+
     steps:
       - name: Checkout Code 🛎
         uses: actions/checkout@v2
@@ -233,7 +233,7 @@ jobs:
               - '.github/workflows/package.yml'
       - name: Cache pip 👜
         uses: actions/cache@v2
-        if: steps.filter.outputs.code_changes == 'true'
+        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE == 'true'
         env:
           # Increase this value to reset cache if pyproject.toml has not changed
           CACHE_NUMBER: 0
@@ -243,18 +243,18 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
-        if: steps.filter.outputs.code_changes == 'true'
+        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE == 'true'
         with:
           node-version: "14"
 
       - name: Build Package 🍟
-        if: steps.filter.outputs.code_changes == 'true'
+        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE == 'true'
         run: |
           pip install -U build
           scripts/build_distribution.sh
 
       - name: Upload package artifact
-        if: steps.filter.outputs.code_changes == 'true'
+        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: python-package
@@ -269,7 +269,7 @@ jobs:
       - test-opensearch
     env:
       IS_DEPLOYABLE: ${{ secrets.AR_DOCKER_USERNAME != '' }}
-    if: needs.build.outputs.code_changes == 'true' && env.IS_DEPLOYABLE == 'true'
+    if: needs.build.outputs.code_changes == 'true'
     strategy:
       matrix:
         include:
@@ -289,30 +289,36 @@ jobs:
     steps:
       - name: Checkout Code 🛎
         uses: actions/checkout@v2
+        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Download python package
         uses: actions/download-artifact@v2
         with:
           name: python-package
           path: dist
+        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Docker meta
         id: meta
         uses: crazy-max/ghaction-docker-meta@v2
         with:
           images: ${{ matrix.image }}
+        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.AR_DOCKER_USERNAME }}
           password: ${{ secrets.AR_DOCKER_PASSWORD }}
+        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Build & push Docker image
         uses: docker/build-push-action@v2
@@ -323,6 +329,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
+        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v3
@@ -331,6 +338,7 @@ jobs:
           password: ${{ secrets.AR_DOCKER_PASSWORD }}
           repository: ${{ matrix.image }}
           readme-filepath: ${{ matrix.readme }}
+        if: env.IS_DEPLOYABLE == 'true'
 
   # This job will upload a Python Package using Twine when a release is created
   # For more information see:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -233,7 +233,7 @@ jobs:
               - '.github/workflows/package.yml'
       - name: Cache pip 👜
         uses: actions/cache@v2
-        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE
+        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE == 'true'
         env:
           # Increase this value to reset cache if pyproject.toml has not changed
           CACHE_NUMBER: 0
@@ -243,18 +243,18 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
-        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE
+        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE == 'true'
         with:
           node-version: "14"
 
       - name: Build Package 🍟
-        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE
+        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE == 'true'
         run: |
           pip install -U build
           scripts/build_distribution.sh
 
       - name: Upload package artifact
-        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE
+        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: python-package
@@ -288,36 +288,36 @@ jobs:
     steps:
       - name: Checkout Code 🛎
         uses: actions/checkout@v2
-        if: env.IS_DEPLOYABLE
+        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Download python package
         uses: actions/download-artifact@v2
         with:
           name: python-package
           path: dist
-        if: env.IS_DEPLOYABLE
+        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-        if: env.IS_DEPLOYABLE
+        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        if: env.IS_DEPLOYABLE
+        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Docker meta
         id: meta
         uses: crazy-max/ghaction-docker-meta@v2
         with:
           images: ${{ matrix.image }}
-        if: env.IS_DEPLOYABLE
+        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.AR_DOCKER_USERNAME }}
           password: ${{ secrets.AR_DOCKER_PASSWORD }}
-        if: env.IS_DEPLOYABLE
+        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Build & push Docker image
         uses: docker/build-push-action@v2
@@ -328,7 +328,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-        if: env.IS_DEPLOYABLE
+        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v3
@@ -337,7 +337,7 @@ jobs:
           password: ${{ secrets.AR_DOCKER_PASSWORD }}
           repository: ${{ matrix.image }}
           readme-filepath: ${{ matrix.readme }}
-        if: env.IS_DEPLOYABLE
+        if: env.IS_DEPLOYABLE == 'true'
 
   # This job will upload a Python Package using Twine when a release is created
   # For more information see:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -208,6 +208,10 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
+    # Only build the package if we can deploy it as a docker image
+    if: secrets.AR_DOCKER_USERNAME != ""
+    outputs:
+      code_changes: ${{ steps.filter.outputs.code_changes }}
 
     steps:
       - name: Checkout Code 🛎
@@ -262,6 +266,8 @@ jobs:
       - build
       - test-elastic
       - test-opensearch
+    # Only deploy if there are code changes
+    if: needs.build.outputs.code_changes == 'true'
     strategy:
       matrix:
         include:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -209,7 +209,8 @@ jobs:
       run:
         shell: bash -l {0}
     # Only build the package if we can deploy it as a docker image
-    if: secrets.AR_DOCKER_USERNAME != ""
+    env:
+      IS_DEPLOYABLE: ${{ secrets.AR_DOCKER_USERNAME != '' }}
     outputs:
       code_changes: ${{ steps.filter.outputs.code_changes }}
 
@@ -232,7 +233,7 @@ jobs:
               - '.github/workflows/package.yml'
       - name: Cache pip 👜
         uses: actions/cache@v2
-        if: steps.filter.outputs.code_changes == 'true'
+        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE
         env:
           # Increase this value to reset cache if pyproject.toml has not changed
           CACHE_NUMBER: 0
@@ -242,18 +243,18 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
-        if: steps.filter.outputs.code_changes == 'true'
+        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE
         with:
           node-version: "14"
 
       - name: Build Package 🍟
-        if: steps.filter.outputs.code_changes == 'true'
+        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE
         run: |
           pip install -U build
           scripts/build_distribution.sh
 
       - name: Upload package artifact
-        if: steps.filter.outputs.code_changes == 'true'
+        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE
         uses: actions/upload-artifact@v2
         with:
           name: python-package
@@ -266,8 +267,8 @@ jobs:
       - build
       - test-elastic
       - test-opensearch
-    # Only deploy if there are code changes
-    if: needs.build.outputs.code_changes == 'true'
+    env:
+      IS_DEPLOYABLE: ${{ secrets.AR_DOCKER_USERNAME != '' }}
     strategy:
       matrix:
         include:
@@ -287,30 +288,36 @@ jobs:
     steps:
       - name: Checkout Code 🛎
         uses: actions/checkout@v2
+        if: env.IS_DEPLOYABLE
 
       - name: Download python package
         uses: actions/download-artifact@v2
         with:
           name: python-package
           path: dist
+        if: env.IS_DEPLOYABLE
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+        if: env.IS_DEPLOYABLE
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        if: env.IS_DEPLOYABLE
 
       - name: Docker meta
         id: meta
         uses: crazy-max/ghaction-docker-meta@v2
         with:
           images: ${{ matrix.image }}
+        if: env.IS_DEPLOYABLE
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.AR_DOCKER_USERNAME }}
           password: ${{ secrets.AR_DOCKER_PASSWORD }}
+        if: env.IS_DEPLOYABLE
 
       - name: Build & push Docker image
         uses: docker/build-push-action@v2
@@ -321,6 +328,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
+        if: env.IS_DEPLOYABLE
 
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v3
@@ -329,6 +337,7 @@ jobs:
           password: ${{ secrets.AR_DOCKER_PASSWORD }}
           repository: ${{ matrix.image }}
           readme-filepath: ${{ matrix.readme }}
+        if: env.IS_DEPLOYABLE
 
   # This job will upload a Python Package using Twine when a release is created
   # For more information see:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -269,6 +269,7 @@ jobs:
       - test-opensearch
     env:
       IS_DEPLOYABLE: ${{ secrets.AR_DOCKER_USERNAME != '' }}
+    if: needs.build.outputs.code_changes == 'true'
     strategy:
       matrix:
         include:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -211,9 +211,9 @@ jobs:
     # Only build the package if we can deploy it as a docker image
     env:
       IS_DEPLOYABLE: ${{ secrets.AR_DOCKER_USERNAME != '' }}
+    if: env.IS_DEPLOYABLE == 'true'
     outputs:
       code_changes: ${{ steps.filter.outputs.code_changes }}
-
     steps:
       - name: Checkout Code 🛎
         uses: actions/checkout@v2
@@ -233,7 +233,7 @@ jobs:
               - '.github/workflows/package.yml'
       - name: Cache pip 👜
         uses: actions/cache@v2
-        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE == 'true'
+        if: steps.filter.outputs.code_changes == 'true'
         env:
           # Increase this value to reset cache if pyproject.toml has not changed
           CACHE_NUMBER: 0
@@ -243,18 +243,18 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
-        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE == 'true'
+        if: steps.filter.outputs.code_changes == 'true'
         with:
           node-version: "14"
 
       - name: Build Package 🍟
-        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE == 'true'
+        if: steps.filter.outputs.code_changes == 'true'
         run: |
           pip install -U build
           scripts/build_distribution.sh
 
       - name: Upload package artifact
-        if: steps.filter.outputs.code_changes == 'true' && env.IS_DEPLOYABLE == 'true'
+        if: steps.filter.outputs.code_changes == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: python-package
@@ -269,7 +269,7 @@ jobs:
       - test-opensearch
     env:
       IS_DEPLOYABLE: ${{ secrets.AR_DOCKER_USERNAME != '' }}
-    if: needs.build.outputs.code_changes == 'true'
+    if: needs.build.outputs.code_changes == 'true' && env.IS_DEPLOYABLE == 'true'
     strategy:
       matrix:
         include:
@@ -289,36 +289,30 @@ jobs:
     steps:
       - name: Checkout Code 🛎
         uses: actions/checkout@v2
-        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Download python package
         uses: actions/download-artifact@v2
         with:
           name: python-package
           path: dist
-        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Docker meta
         id: meta
         uses: crazy-max/ghaction-docker-meta@v2
         with:
           images: ${{ matrix.image }}
-        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.AR_DOCKER_USERNAME }}
           password: ${{ secrets.AR_DOCKER_PASSWORD }}
-        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Build & push Docker image
         uses: docker/build-push-action@v2
@@ -329,7 +323,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-        if: env.IS_DEPLOYABLE == 'true'
 
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v3
@@ -338,7 +331,6 @@ jobs:
           password: ${{ secrets.AR_DOCKER_PASSWORD }}
           repository: ${{ matrix.image }}
           readme-filepath: ${{ matrix.readme }}
-        if: env.IS_DEPLOYABLE == 'true'
 
   # This job will upload a Python Package using Twine when a release is created
   # For more information see:


### PR DESCRIPTION
Hello!

## Pull Request overview
* Skip CI jobs rather than letting them fail in 2 common scenarios:
  1. If a PR is created from a fork.
  2. If a PR does not contain code changes.

## Problems
### Scenario 1
If a PR is created from a fork, then certain secrets will be inaccessible, e.g. `secrets.AR_DOCKER_USERNAME` and `secrets.AR_DOCKER_PASSWORD`. This causes the "Docker Deploy" job to fail, understandably. It would be better if these jobs would be skipped instead.
See [here](https://github.com/argilla-io/argilla/actions/runs/4240437103/jobs/7369703791) for an example case.

### Scenario 2
There are two subsequent jobs: One to build the Python package, and one to deploy it as a Docker image. The first one will stop halfway through if there are no code changes found in the PR, but the second job will still try to deploy the build artifact. Upon trying to load it, it will crash.
See [here](https://github.com/argilla-io/argilla/actions/runs/4229327600/jobs/7345607762) for an example case.

## Fixes
### Scenario 1
Sadly, secrets are not accessible on the `build.if` and `deploy_docker.if` level, so we can't use e.g. `if: secrets.AR_DOCKER_USERNAME != ''`. Instead, we are required to use an environment variable, e.g. `IS_DEPLOYABLE` to track whether the secrets are accessible, and then add `if env.IS_DEPLOYABLE == 'true'` to all steps.

### Scenario 2
This was as simple as setting `code_outputs` as an output from the `build` job, which can then be read as input for the `deploy_docker` job. This job is now skipped if there are no code changes in the PR/commit.

---

**Type of change**

- [x] Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**

Through this PR. Note: I have only been able to test scenario 1 (PR from a fork). I haven't been able to test scenario 2 nor the "normal" scenarios where these jobs do actually execute (i.e. first-party PR with code changes). These are annoying to test easily. I think we're best off merging this and reverting if any scenarios work unexpectedly, rather than trying to test all of the scenarios in a separate repo.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

---

With this PR I hope to have reached the point where CI failures imply actual issues and CI passes imply that a PR is "likely ready".

- Tom Aarsen